### PR TITLE
【Fixed】rails g コマンドの際いらないファイルが生成されないようにした

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,10 @@ module InstagramClone
 
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1 
rails g コマンドの際いらないファイルが生成されないようにした
config/application.rbのclass Application < Rails::Application内に
config.generators do |g|
      g.assets     false
      g.helper     false
end
を追加した。